### PR TITLE
fix: remove extra slash in websocket URL

### DIFF
--- a/injected.html
+++ b/injected.html
@@ -18,7 +18,7 @@
 				}
 			}
 			var protocol = window.location.protocol === 'http:' ? 'ws://' : 'wss://';
-			var address = protocol + window.location.host + window.location.pathname + '/ws';
+			var address = protocol + window.location.host + window.location.pathname.replace(/\/$/, "") + '/ws';
 			var socket = new WebSocket(address);
 			socket.onmessage = function(msg) {
 				if (msg.data == 'reload') window.location.reload();


### PR DESCRIPTION
Caddy server will issue a redirect from `//ws` to `/ws` 
which breaks the websocket -- this change fixes the issue